### PR TITLE
Fix plugin install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author="Antoine Beyeler",
     url="",
     license=license,
-    packages=find_packages(exclude=("examples", "tests")),
+    packages=["vpype_text"],
     install_requires=[
         'click',
         'vpype @ git+https://github.com/abey79/vpype.git',


### PR DESCRIPTION
When installed normally, the plug-in would not load correctly (no actual source file installed by pip). Fix: avoid using `find_package`